### PR TITLE
Add method to open a file from scripts

### DIFF
--- a/WorldPainter/WPGUI/src/main/java/org/pepsoft/worldpainter/tools/scripts/ScriptRunner.java
+++ b/WorldPainter/WPGUI/src/main/java/org/pepsoft/worldpainter/tools/scripts/ScriptRunner.java
@@ -397,8 +397,9 @@ public class ScriptRunner extends WorldPainterDialog {
 		
 		File file = FileUtils.selectFileForOpen(fileWindow, title, null, filter);
 
-		if (file != null)
+		if (file != null) {
 			return file.getAbsolutePath();
+		}
 		return "";
 	}
 

--- a/WorldPainter/WPGUI/src/main/java/org/pepsoft/worldpainter/tools/scripts/ScriptRunner.java
+++ b/WorldPainter/WPGUI/src/main/java/org/pepsoft/worldpainter/tools/scripts/ScriptRunner.java
@@ -392,8 +392,7 @@ public class ScriptRunner extends WorldPainterDialog {
      * @param extensions extension names without the dot in front separated with a space
      * @return absolute path to the selected file or a blank String if canceled
      */
-	public static String getFilePath(String title, String extensionName, String extensions)
-	{
+	public static String getFilePath(String title, String extensionName, String extensions) {
 		FileFilter filter = new FileNameExtensionFilter(extensionName, extensions.split(" "));
 		
 		File file = FileUtils.selectFileForOpen(fileWindow, title, null, filter);

--- a/WorldPainter/WPGUI/src/main/java/org/pepsoft/worldpainter/tools/scripts/ScriptRunner.java
+++ b/WorldPainter/WPGUI/src/main/java/org/pepsoft/worldpainter/tools/scripts/ScriptRunner.java
@@ -47,6 +47,9 @@ public class ScriptRunner extends WorldPainterDialog {
         this.dimension = dimension;
         this.undoManagers = undoManagers;
 
+        // Stores self in a static variable for use with file loading for scripts
+        fileWindow = this;
+
         initComponents();
         
         Configuration config = Configuration.getInstance();
@@ -379,6 +382,26 @@ public class ScriptRunner extends WorldPainterDialog {
             }
         }.start();
     }
+	
+	private static ScriptRunner fileWindow;
+
+	/**
+     * Returns the absolute path to the selected file for use with scripts
+     * @param title name of the window that opens and prompts for a file
+     * @param extensionName name of list of allowed extensions
+     * @param extensions extension names without the dot in front separated with a space
+     * @return absolute path to the selected file or a blank String if canceled
+     */
+	public static String getFilePath(String title, String extensionName, String extensions)
+	{
+		FileFilter filter = new FileNameExtensionFilter(extensionName, extensions.split(" "));
+		
+		File file = FileUtils.selectFileForOpen(fileWindow, title, null, filter);
+
+		if (file != null)
+			return file.getAbsolutePath();
+		return "";
+	}
 
     /**
      * This method is called from within the constructor to initialize the form.


### PR DESCRIPTION
Hi, CaptainChaos. I implemented a method to easily load files from scripts. I don't know how to install dependencies :(, so this is untested, but theoretically it should work.
From a script, I would use
`var fileDir = org.pepsoft.worldpainter.tools.scripts.ScriptRunner.getFilePath("Open heightmap", "Images", "png jpg jpeg");`