### PR TITLE
Add support for multiple palettes

### DIFF
--- a/WorldPainter/WPCore/src/main/java/org/pepsoft/minecraft/Constants.java
+++ b/WorldPainter/WPCore/src/main/java/org/pepsoft/minecraft/Constants.java
@@ -634,6 +634,7 @@ public final class Constants {
     public static final String TAG_PALETTE                 = "Palette";
     /** Lower case variant. */
     public static final String TAG_PALETTE_                = "palette";
+    public static final String TAG_PALETTES                = "palettes";
     public static final String TAG_NAME                    = "Name";
     public static final String TAG_PROPERTIES              = "Properties";
     public static final String TAG_SNAPSHOT                = "Snapshot";


### PR DESCRIPTION
Minecraft shipwrecks use multiple palettes, allowing a single structure file to contain various schemes depending on the location the structure is placed.

All of the code supporting this exists, except for the actual loading of multiple palettes. `Structure.setSeed()` is called using the chunk coords, and `Structure.getObject()` as well, prior to rendering the final object into the world.

Attempting to load an NBT file with multiple palettes causes a `NullPointerException` and provides no information about the error. Now, loading an NBT with multiple palettes is supported and works as expected.

Unfortunately I was not able to test this as I couldn't build this myself. However, since the changes are so few and the code is clear, I'm confident this will work perfectly with all existing worlds, objects, etc.