### PR TITLE
Add scripting API call for using multiple heightmaps

### DIFF
--- a/WorldPainter/WPCore/src/main/java/org/pepsoft/worldpainter/tools/scripts/ScriptingContext.java
+++ b/WorldPainter/WPCore/src/main/java/org/pepsoft/worldpainter/tools/scripts/ScriptingContext.java
@@ -140,7 +140,18 @@ public class ScriptingContext {
      */
     public MappingOp applyHeightMap(HeightMap heightMap) throws ScriptException {
         checkGoCalled("applyHeightMap");
-        return new MappingOp(this, heightMap);
+        return new MappingOp(this, heightMap, false);
+    }
+
+
+    /**
+     * Map a height map to a portion of the world. Affects the terrain of the world.
+     * @param heightMap the height map to apply.
+     * @return
+     */
+    public MappingOp addHeightMap(HeightMap heightMap) throws ScriptException {
+        checkGoCalled("addHeightMap");
+        return new MappingOp(this, heightMap, true);
     }
     
     /**


### PR DESCRIPTION
Adds a JS call named "addHeightMap" so that multiple height alterating maps can be used in the same world. I believe this is all that is needed for it to work, I tested two heightmaps out and it did indeed place them into the world.

https://github.com/Captain-Chaos/WorldPainter/issues/110