### PR TITLE
create a DefaultFilter.LayerValue instead of using the straight biome index

### DIFF
--- a/WorldPainter/WPCore/src/main/java/org/pepsoft/worldpainter/tools/scripts/CreateFilterOp.java
+++ b/WorldPainter/WPCore/src/main/java/org/pepsoft/worldpainter/tools/scripts/CreateFilterOp.java
@@ -19,6 +19,7 @@
 package org.pepsoft.worldpainter.tools.scripts;
 
 import org.pepsoft.worldpainter.Terrain;
+import org.pepsoft.worldpainter.layers.Biome;
 import org.pepsoft.worldpainter.layers.Layer;
 import org.pepsoft.worldpainter.operations.Filter;
 import org.pepsoft.worldpainter.panels.DefaultFilter;
@@ -139,7 +140,7 @@ public class CreateFilterOp extends AbstractOperation<Filter> {
         if (onlyOn != null) {
             throw new ScriptException("Only one \"only on\" or condition may be specified");
         }
-        onlyOn = biomeIndex;
+        onlyOn = new DefaultFilter.LayerValue(Biome.INSTANCE, biomeIndex);
         exceptOnLastSet = false;
         return this;
     }


### PR DESCRIPTION
closes https://github.com/Captain-Chaos/WorldPainter/issues/153
Noticed that other places where the filter was being created it used a DefaultFilter.LayerValue so I just applied the same logic here.
![image](https://user-images.githubusercontent.com/30448663/84293375-4e038700-ab0d-11ea-9a7a-80982515e7f7.PNG)
