### PR TITLE
Add Linux data files

### DIFF
--- a/net.worldpainter.worldpainter.desktop
+++ b/net.worldpainter.worldpainter.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=WorldPainter
+Type=Application
+Terminal=false
+Icon=net.worldpainter.worldpainter
+Exec=worldpainter
+Comment=An interactive map generator for Minecraft
+Categories=Game;Java;
+MimeType=application/x-worldpainter-world;

--- a/net.worldpainter.worldpainter.metainfo.xml
+++ b/net.worldpainter.worldpainter.metainfo.xml
@@ -1,0 +1,146 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="desktop">
+  <!--Created with jdAppdataEdit 4.2-->
+  <id>net.worldpainter.worldpainter</id>
+  <name>WorldPainter</name>
+  <summary>An interactive map generator for Minecraft</summary>
+  <developer_name>Captain-Chaos</developer_name>
+  <launchable type="desktop-id">net.worldpainter.worldpainter.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <description>
+    <p>WorldPainter is an interactive map generator for Minecraft. It allows you to "paint" landscapes using similar tools as a regular paint program. Sculpt and mould the terrain, paint materials, trees, snow and ice, etc. onto it, and much more.</p>
+  </description>
+  <releases>
+    <release version="v2.12.0" date="2022-08-04" type="stable"/>
+    <release version="v2.11.0" date="2022-07-24" type="stable"/>
+    <release version="v2.10.14" date="2022-07-20" type="stable"/>
+    <release version="v2.10.13" date="2022-07-14" type="stable"/>
+    <release version="v2.10.12" date="2022-07-11" type="stable"/>
+    <release version="v2.10.11" date="2022-06-27" type="stable"/>
+    <release version="v2.10.10" date="2022-06-02" type="stable"/>
+    <release version="v2.10.9" date="2022-05-31" type="stable"/>
+    <release version="v2.10.8" date="2022-05-28" type="stable"/>
+    <release version="v2.10.7" date="2022-05-25" type="stable"/>
+    <release version="v2.10.6" date="2022-05-25" type="stable"/>
+    <release version="v2.10.5" date="2022-05-18" type="stable"/>
+    <release version="v2.10.4" date="2022-05-17" type="stable"/>
+    <release version="v2.10.3" date="2022-05-15" type="stable"/>
+    <release version="v2.10.2" date="2022-05-14" type="stable"/>
+    <release version="v2.10.1" date="2022-05-13" type="stable"/>
+    <release version="v2.10.0" date="2022-05-13" type="stable"/>
+    <release version="v2.9.7" date="2022-05-09" type="stable"/>
+    <release version="v2.9.5" date="2022-05-06" type="stable"/>
+    <release version="v2.9.4" date="2022-05-05" type="stable"/>
+    <release version="v2.9.3" date="2022-05-04" type="stable"/>
+    <release version="v2.9.2" date="2022-05-03" type="stable"/>
+    <release version="v2.9.1" date="2022-05-02" type="stable"/>
+    <release version="v2.9.0" date="2022-05-01" type="stable"/>
+    <release version="v2.8.10" date="2021-12-13" type="stable"/>
+    <release version="v2.8.9" date="2021-12-10" type="stable"/>
+    <release version="v2.8.8" date="2021-12-09" type="stable"/>
+    <release version="v2.8.7" date="2021-12-08" type="stable"/>
+    <release version="v2.8.6" date="2021-12-06" type="stable"/>
+    <release version="v2.8.5" date="2021-12-06" type="stable"/>
+    <release version="v2.8.4" date="2021-12-05" type="stable"/>
+    <release version="v2.8.3" date="2021-11-06" type="stable"/>
+    <release version="2.8.2" date="2021-11-06" type="stable"/>
+    <release version="v2.8.1" date="2021-06-27" type="stable"/>
+    <release version="v2.8.0" date="2021-04-18" type="stable"/>
+    <release version="v2.7.18" date="2020-12-27" type="stable"/>
+    <release version="v2.7.17" date="2020-09-03" type="stable"/>
+    <release version="v2.7.16" date="2020-06-14" type="stable"/>
+    <release version="v2.7.15" date="2020-06-12" type="stable"/>
+    <release version="v2.7.14" date="2020-06-07" type="stable"/>
+    <release version="v2.7.13" date="2020-06-07" type="stable"/>
+    <release version="v2.7.12" date="2020-06-06" type="stable"/>
+    <release version="v2.7.11" date="2020-06-05" type="stable"/>
+    <release version="v2.7.10" date="2020-05-17" type="stable"/>
+    <release version="v2.7.9" date="2020-05-17" type="stable"/>
+    <release version="v2.7.8" date="2020-05-10" type="stable"/>
+    <release version="v2.7.7" date="2020-04-25" type="stable"/>
+    <release version="v2.7.6" date="2020-04-18" type="stable"/>
+    <release version="v2.7.5" date="2019-12-08" type="stable"/>
+    <release version="v2.7.4" date="2019-10-20" type="stable"/>
+    <release version="v2.7.3" date="2019-09-15" type="stable"/>
+    <release version="v2.7.2" date="2019-09-12" type="stable"/>
+    <release version="v2.7.1" date="2019-09-03" type="stable"/>
+    <release version="v2.7.0" date="2019-08-18" type="stable"/>
+    <release version="v2.6.5" date="2019-06-02" type="stable"/>
+    <release version="v2.6.4" date="2019-06-01" type="stable"/>
+    <release version="v2.6.3" date="2019-06-01" type="stable"/>
+    <release version="v2.6.2" date="2019-05-31" type="stable"/>
+    <release version="v2.6.1" date="2019-05-27" type="stable"/>
+    <release version="v2.6.0" date="2019-05-26" type="stable"/>
+    <release version="v2.6.0.RC1" date="2019-04-22" type="stable"/>
+    <release version="v2.5.12" date="2019-03-17" type="stable"/>
+    <release version="v2.5.111" date="2019-03-09" type="stable"/>
+    <release version="v2.5.10" date="2019-02-22" type="stable"/>
+    <release version="v2.5.9" date="2019-02-10" type="stable"/>
+    <release version="v2.5.8" date="2018-11-18" type="stable"/>
+    <release version="v2.5.7" date="2018-09-05" type="stable"/>
+    <release version="v2.5.6" date="2018-07-28" type="stable"/>
+    <release version="v2.5.5" date="2018-07-04" type="stable"/>
+    <release version="v2.5.4" date="2018-06-22" type="stable"/>
+    <release version="v2.5.3" date="2018-06-18" type="stable"/>
+    <release version="v2.5.2" date="2018-06-16" type="stable"/>
+    <release version="v2.5.1" date="2018-05-08" type="stable"/>
+    <release version="v2.5.0" date="2018-04-23" type="stable"/>
+    <release version="v2.4.8" date="2018-04-21" type="stable"/>
+    <release version="v2.4.7" date="2018-04-18" type="stable"/>
+    <release version="v2.4.6" date="2018-04-18" type="stable"/>
+    <release version="v2.4.5" date="2018-04-17" type="stable"/>
+    <release version="v2.4.4" date="2018-04-13" type="stable"/>
+    <release version="v2.4.3" date="2018-02-05" type="stable"/>
+    <release version="v2.4.2" date="2018-02-01" type="stable"/>
+    <release version="v2.4.1" date="2017-02-05" type="stable"/>
+    <release version="v2.4.0" date="2017-02-04" type="stable"/>
+    <release version="v2.3.6" date="2017-01-05" type="stable"/>
+    <release version="v2.3.5" date="2017-01-04" type="stable"/>
+    <release version="v2.3.4" date="2016-12-26" type="stable"/>
+    <release version="v2.3.3" date="2016-12-23" type="stable"/>
+    <release version="v2.3.2" date="2016-12-09" type="stable"/>
+    <release version="v2.3.1" date="2016-12-04" type="stable"/>
+    <release version="v2.3.0" date="2016-11-27" type="stable"/>
+    <release version="v2.2.6" date="2016-10-25" type="stable"/>
+    <release version="v2.2.5" date="2016-10-23" type="stable"/>
+    <release version="v2.2.4" date="2016-08-20" type="stable"/>
+    <release version="v2.2.3" date="2016-08-07" type="stable"/>
+    <release version="v2.2.2" date="2016-08-06" type="stable"/>
+    <release version="v2.2.1" date="2016-08-06" type="stable"/>
+    <release version="v2.2.0" date="2016-03-18" type="stable"/>
+    <release version="v2.1.6" date="2016-02-07" type="stable"/>
+    <release version="v2.1.5" date="2016-02-07" type="stable"/>
+    <release version="v2.1.4" date="2016-01-17" type="stable"/>
+    <release version="v2.1.3" date="2015-11-29" type="stable"/>
+    <release version="v2.1.2" date="2015-11-24" type="stable"/>
+    <release version="v2.1.1" date="2015-11-23" type="stable"/>
+    <release version="v2.1.0" date="2015-11-22" type="stable"/>
+    <release version="v2.0.2" date="2015-09-27" type="stable"/>
+    <release version="v2.0.1" date="2015-09-18" type="stable"/>
+    <release version="v2.0.0" date="2015-09-13" type="stable"/>
+    <release version="v1.11.2" date="2015-06-28" type="stable"/>
+    <release version="V1.11.1" date="2015-04-26" type="stable"/>
+    <release version="V1.11.0" date="2015-04-25" type="stable"/>
+    <release version="v1.10.6" date="2015-03-07" type="stable"/>
+    <release version="v1.10.5" date="2015-03-01" type="stable"/>
+  </releases>
+  <url type="homepage">https://www.worldpainter.net/</url>
+  <url type="bugtracker">https://github.com/Captain-Chaos/WorldPainter/issues</url>
+  <url type="faq">https://www.worldpainter.net/doc/faq</url>
+  <url type="help">https://www.worldpainter.net/doc/</url>
+  <url type="vcs-browser">https://github.com/Captain-Chaos/WorldPainter</url>
+  <categories>
+    <category>Game</category>
+    <category>Java</category>
+  </categories>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+  </recommends>
+  <content_rating type="oars-1.1"/>
+  <provides>
+    <binary>worldpainter</binary>
+    <mediatype>application/x-worldpainter-world</mediatype>
+  </provides>
+</component>

--- a/x-worldpainter-world.xml
+++ b/x-worldpainter-world.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+    <mime-type type="application/x-worldpainter-world">
+        <generic-icon name="net.worldpainter.worldpainter"/>
+        <comment>Worldpainter World</comment>
+        <glob pattern="*.world"/>
+    </mime-type>
+</mime-info>


### PR DESCRIPTION
This PR adds a few data files for Linux in preparation of #214. This includes a .desktop file for the menu, a AppStream file for the Flathub Website and the Software center and a custom MimeType for the .world files.

The AppStream file still needs a Screenshot. If you have a official one, please provide the Link.