### PR TITLE
Feature/scripts remember parameters

### DIFF
--- a/WorldPainter/WPGUI/src/main/java/org/pepsoft/worldpainter/tools/scripts/ScriptRunner.java
+++ b/WorldPainter/WPGUI/src/main/java/org/pepsoft/worldpainter/tools/scripts/ScriptRunner.java
@@ -196,7 +196,7 @@ public class ScriptRunner extends WorldPainterDialog {
         constraints.gridwidth = GridBagConstraints.REMAINDER;
         panel.add(component, constraints);
     }
-    
+
     private ScriptDescriptor analyseScript(File script) {
         if (! script.isFile()) {
             return null;
@@ -307,25 +307,34 @@ public class ScriptRunner extends WorldPainterDialog {
      * selects the descriptor to use for the script.
      * <p>
      * If the oldDescriptor map has a descriptor with the same name and same parameter names, the old one is used.
-     * if not, the new one is used. Nullsafe
+     * if not, the new one is used.
      *
      * @param oldDescriptors
      * @param newDescriptor
      * @return
      */
-    @NotNull
-    private static ScriptDescriptor selectDescriptor(final HashMap<String, ScriptDescriptor> oldDescriptors, ScriptDescriptor newDescriptor) {
-        if (newDescriptor.name == null || !scriptPropertyMap.containsKey(newDescriptor.name))
+    public static ScriptDescriptor selectDescriptor(final HashMap<String, ScriptDescriptor> oldDescriptors, ScriptDescriptor newDescriptor) {
+        if (newDescriptor.name == null || !oldDescriptors.containsKey(newDescriptor.name))
             return newDescriptor;
 
         ScriptDescriptor mappedDescriptor = oldDescriptors.get(newDescriptor.name);
 
-        boolean paramsMissing = newDescriptor.parameterDescriptors.stream().anyMatch(param -> !mappedDescriptor.getValues().containsKey(param.name));
+        boolean paramsMissing = !newDescriptor.parameterDescriptors.stream().allMatch(
+                p -> hasDescriptorWithNameAndType(mappedDescriptor.parameterDescriptors, p));
         if (paramsMissing)
             return newDescriptor;
 
         return mappedDescriptor;
 
+    }
+
+    public static boolean hasDescriptorWithNameAndType(List<ParameterDescriptor> list, ParameterDescriptor descriptorA) {
+        for (ParameterDescriptor descriptorB : list) {
+            if (descriptorB.name.equals(descriptorA.name) && descriptorB.getClass().equals(descriptorA.getClass()))
+                return true;
+
+        }
+        return false;
     }
 
     private void run() {
@@ -805,6 +814,13 @@ public class ScriptRunner extends WorldPainterDialog {
     }
 
     static class StringParameterDescriptor extends ParameterDescriptor<String, JTextField> {
+        public StringParameterDescriptor(String name) {
+            this.name = name;
+        }
+
+        public StringParameterDescriptor() {
+        }
+
         @Override
         protected JTextField createEditor() {
             JTextField field = new JTextField(defaultValue);
@@ -850,6 +866,15 @@ public class ScriptRunner extends WorldPainterDialog {
     }
 
     static class IntegerParameterDescriptor extends ParameterDescriptor<Integer, JSpinner> {
+        public IntegerParameterDescriptor(String name) {
+            super();
+            this.name = name;
+        }
+
+        public IntegerParameterDescriptor() {
+            super();
+        }
+
         @Override
         protected JSpinner createEditor() {
             JSpinner spinner = new JSpinner();

--- a/WorldPainter/WPGUI/src/test/java/org/pepsoft/worldpainter/tools/scripts/ScriptRunnerTest.java
+++ b/WorldPainter/WPGUI/src/test/java/org/pepsoft/worldpainter/tools/scripts/ScriptRunnerTest.java
@@ -1,0 +1,47 @@
+package org.pepsoft.worldpainter.tools.scripts;
+
+import org.junit.Test;
+import java.util.HashMap;
+import java.util.Objects;
+
+public class ScriptRunnerTest  {
+    @Test
+    public void testChooseScriptDescriptor() {
+        HashMap<String, ScriptRunner.ScriptDescriptor> map = new HashMap<>();
+
+        //empty map
+        final ScriptRunner.ScriptDescriptor myNewScriptParams = new ScriptRunner.ScriptDescriptor();
+        assert ScriptRunner.selectDescriptor(map, myNewScriptParams) == myNewScriptParams; //should be same object
+
+        //map with null key
+        map.put(null, new ScriptRunner.ScriptDescriptor());
+        assert ScriptRunner.selectDescriptor(map, myNewScriptParams) == myNewScriptParams; //should be same object
+
+        final String descriptorName = "myName";
+
+        myNewScriptParams.name = descriptorName;
+        myNewScriptParams.parameterDescriptors.add(new ScriptRunner.IntegerParameterDescriptor("an Integer parameter"));
+        assert myNewScriptParams.parameterDescriptors.size() == 1;
+
+
+        ScriptRunner.ScriptDescriptor oldScriptParams = new ScriptRunner.ScriptDescriptor();
+        oldScriptParams.name = descriptorName;
+        map.put(descriptorName, oldScriptParams);
+
+        //name match but parameter mismatch
+        assert ScriptRunner.selectDescriptor(map, myNewScriptParams) == myNewScriptParams; //should be same object
+
+        //name match and parameter match
+        oldScriptParams.parameterDescriptors.add(new ScriptRunner.IntegerParameterDescriptor("an Integer parameter"));
+        assert Objects.equals(oldScriptParams.name, myNewScriptParams.name);
+        assert Objects.equals(oldScriptParams.parameterDescriptors.get(0).name, myNewScriptParams.parameterDescriptors.get(0).name);
+        assert map.get(descriptorName) == oldScriptParams; //should be same object
+
+        assert ScriptRunner.selectDescriptor(map, myNewScriptParams) == oldScriptParams; //should be same object
+
+        //name match, parameter name match, parameter type mismatch
+        oldScriptParams.parameterDescriptors.set(0, new ScriptRunner.StringParameterDescriptor("an Integer parameter"));
+        assert ScriptRunner.selectDescriptor(map, myNewScriptParams) == myNewScriptParams; //should be same object
+
+    }
+}


### PR DESCRIPTION
scriptrunner saves the name and parameters of a script when script is run.
if the user opens the "run script" window again, and the loaded script has the same name, and all parameters match in name and type, the saved parameters are used.

this means, that the user does not have to re-select the same parameters over and over again, for each running of the same script.
only persists during lifetime of worldpainter app

