### PR TITLE
Autocomplete for material selector

### DIFF
--- a/WorldPainter/WPCore/src/main/java/org/pepsoft/worldpainter/panels/SearchableJComboBox.java
+++ b/WorldPainter/WPCore/src/main/java/org/pepsoft/worldpainter/panels/SearchableJComboBox.java
@@ -1,0 +1,81 @@
+package org.pepsoft.worldpainter.panels;
+
+import javax.swing.*;
+import javax.swing.plaf.basic.BasicComboBoxEditor;
+import java.awt.event.*;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+public class SearchableJComboBox extends JComboBox<String> {
+    public SearchableJComboBox(String[] entries) {
+        super(entries);
+        setup();
+    }
+
+    public SearchableJComboBox() {
+        super();
+        setup();
+    }
+
+    private void setup() {
+        setEditable(true);
+        setEditor(new SearchEditor (this));
+    }
+
+    public String[] getEntries() {
+        int size = this.getItemCount();
+        String[] entries = new String[size];
+
+        for (int index = 0; index < size; index++) {
+            String data = getItemAt(index);
+            entries[index] = data;
+        }
+
+        return entries;
+    }
+
+    private static class SearchEditor extends BasicComboBoxEditor {
+        public SearchEditor (final SearchableJComboBox searchableJComboBox) {
+            KeyAdapter listener = new KeyAdapter() {
+                public void keyReleased(KeyEvent event) {
+                    String[] entries = searchableJComboBox.getEntries();
+
+                    if ((event.getKeyChar() >= 'a' && event.getKeyChar() <= 'z') ||
+                            (event.getKeyChar() >= 'A' && event.getKeyChar() <= 'Z') ||
+                            (event.getKeyChar() == KeyEvent.VK_UNDERSCORE)
+                    ) {
+                        String searchText = editor.getText();
+
+                        Predicate<String> matchesStart = entry -> entry.startsWith(searchText);
+                        Optional<String> firstMatch = Arrays.stream(entries).filter(matchesStart).findFirst();
+
+                        if (!firstMatch.isPresent()) return;
+                        String finalText = firstMatch.get();
+
+                        if (finalText.equals("")) finalText = searchText;
+
+                        if (!finalText.equals(searchText)) {
+                            editor.setText(finalText);
+                            editor.setSelectionStart(searchText.length());
+                            editor.setSelectionEnd(finalText.length());
+                        }
+
+                        searchableJComboBox.setSelectedItem(finalText);
+                    }
+                }
+            };
+
+            editor.addKeyListener(listener);
+
+            ActionListener actionListener = e -> {
+                if (searchableJComboBox.getSelectedItem() != null && ! editor.getText().equals(searchableJComboBox.getSelectedItem().toString())) {
+                    editor.setText(searchableJComboBox.getSelectedItem().toString());
+                }
+            };
+            searchableJComboBox.addActionListener(actionListener);
+        }
+    }
+}
+
+

--- a/WorldPainter/WPCore/src/main/java/org/pepsoft/worldpainter/panels/SearchableJComboBox.java
+++ b/WorldPainter/WPCore/src/main/java/org/pepsoft/worldpainter/panels/SearchableJComboBox.java
@@ -53,6 +53,8 @@ public class SearchableJComboBox extends JComboBox<String> {
                         if (!firstMatch.isPresent()) return;
                         String finalText = firstMatch.get();
 
+                        searchableJComboBox.showPopup();
+
                         if (finalText.equals("")) finalText = searchText;
 
                         if (!finalText.equals(searchText)) {

--- a/WorldPainter/WPGUI/src/main/java/org/pepsoft/worldpainter/MaterialSelector.java
+++ b/WorldPainter/WPGUI/src/main/java/org/pepsoft/worldpainter/MaterialSelector.java
@@ -7,6 +7,7 @@ package org.pepsoft.worldpainter;
 
 import org.pepsoft.minecraft.Material;
 import org.pepsoft.util.DesktopUtils;
+import org.pepsoft.worldpainter.panels.SearchableJComboBox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -467,7 +468,7 @@ public class MaterialSelector extends javax.swing.JPanel {
         radioButtonCustom = new javax.swing.JRadioButton();
         jLabel1 = new javax.swing.JLabel();
         jLabel2 = new javax.swing.JLabel();
-        comboBoxMinecraftName = new javax.swing.JComboBox<>();
+        comboBoxMinecraftName = new SearchableJComboBox();
         comboBoxNamespace = new javax.swing.JComboBox<>();
         radioButtonMinecraft = new javax.swing.JRadioButton();
         comboBoxCustomName = new javax.swing.JComboBox<>();
@@ -797,7 +798,7 @@ public class MaterialSelector extends javax.swing.JPanel {
     private javax.swing.ButtonGroup buttonGroup1;
     private javax.swing.JComboBox<String> comboBoxBlockType;
     private javax.swing.JComboBox<String> comboBoxCustomName;
-    private javax.swing.JComboBox<String> comboBoxMinecraftName;
+    private SearchableJComboBox comboBoxMinecraftName;
     private javax.swing.JComboBox<String> comboBoxNamespace;
     private javax.swing.JLabel jLabel1;
     private javax.swing.JLabel jLabel2;


### PR DESCRIPTION
Based on an implementation described [here](https://jstomp.sourceforge.net/comboBox/search.html).

Makes the JComboBox containing the Minecraft materials editable, and automatically highlights the first item with the entered prefix. 

![image](https://github.com/Captain-Chaos/WorldPainter/assets/57606752/57fe7fa0-50ae-4889-8678-560038120d6a)
