### PR TITLE
Bugfix/filter in script

### DIFF
--- a/WorldPainter/WPCore/src/main/java/org/pepsoft/worldpainter/panels/ExceptOnTerrainOrLayerFilter.java
+++ b/WorldPainter/WPCore/src/main/java/org/pepsoft/worldpainter/panels/ExceptOnTerrainOrLayerFilter.java
@@ -39,17 +39,17 @@ public class ExceptOnTerrainOrLayerFilter extends TerrainOrLayerFilter {
                 }
                 break;
             case INT_LAYER_EQUAL:
-                if (dimension.getLayerValueAt(layer, x, y) != value) {
+                if (dimension.getLayerValueAt(layer, x, y) == value) {
                     return 0.0f;
                 }
                 break;
             case INT_LAYER_EQUAL_OR_HIGHER:
-                if (dimension.getLayerValueAt(layer, x, y) < value) {
+                if (dimension.getLayerValueAt(layer, x, y) >= value) {
                     return 0.0f;
                 }
                 break;
             case INT_LAYER_EQUAL_OR_LOWER:
-                if (dimension.getLayerValueAt(layer, x, y) > value) {
+                if (dimension.getLayerValueAt(layer, x, y) <= value) {
                     return 0.0f;
                 }
                 break;

--- a/WorldPainter/WPCore/src/main/java/org/pepsoft/worldpainter/panels/OnlyOnTerrainOrLayerFilter.java
+++ b/WorldPainter/WPCore/src/main/java/org/pepsoft/worldpainter/panels/OnlyOnTerrainOrLayerFilter.java
@@ -39,17 +39,17 @@ public class OnlyOnTerrainOrLayerFilter extends TerrainOrLayerFilter {
                 }
                 break;
             case INT_LAYER_EQUAL:
-                if (dimension.getLayerValueAt(layer, x, y) == value) {
+                if (dimension.getLayerValueAt(layer, x, y) != value) {
                     return 0.0f;
                 }
                 break;
             case INT_LAYER_EQUAL_OR_HIGHER:
-                if (dimension.getLayerValueAt(layer, x, y) >= value) {
+                if (dimension.getLayerValueAt(layer, x, y) < value) {
                     return 0.0f;
                 }
                 break;
             case INT_LAYER_EQUAL_OR_LOWER:
-                if (dimension.getLayerValueAt(layer, x, y) <= value) {
+                if (dimension.getLayerValueAt(layer, x, y) > value) {
                     return 0.0f;
                 }
                 break;

--- a/WorldPainter/WPCore/src/main/java/org/pepsoft/worldpainter/tools/scripts/CreateFilterOp.java
+++ b/WorldPainter/WPCore/src/main/java/org/pepsoft/worldpainter/tools/scripts/CreateFilterOp.java
@@ -26,8 +26,7 @@ import org.pepsoft.worldpainter.panels.DefaultFilter;
 import org.pepsoft.worldpainter.panels.DefaultFilter.LayerValue;
 import org.pepsoft.worldpainter.panels.TerrainOrLayerFilter;
 
-import static org.pepsoft.worldpainter.panels.DefaultFilter.Condition.HIGHER_THAN_OR_EQUAL;
-import static org.pepsoft.worldpainter.panels.DefaultFilter.Condition.LOWER_THAN_OR_EQUAL;
+import static org.pepsoft.worldpainter.panels.DefaultFilter.Condition.*;
 
 /**
  *
@@ -100,7 +99,7 @@ public class CreateFilterOp extends AbstractOperation<Filter> {
         if (exceptOnLastSet) {
             if (exceptOn instanceof Layer) {
                 throw new ScriptException("No \"except on\" layer value specified for \"or higher\"");
-            } else if (((LayerValue) exceptOn).condition != null) {
+            } else if (((LayerValue) exceptOn).condition != null && ((LayerValue) exceptOn).condition != EQUAL) {
                 throw new ScriptException("Only one of \"or lower\" and \"or higher\" may be specified for \"except on\" value");
             }
             exceptOn = new LayerValue(((LayerValue) exceptOn).layer, ((LayerValue) exceptOn).value, HIGHER_THAN_OR_EQUAL);
@@ -109,7 +108,7 @@ public class CreateFilterOp extends AbstractOperation<Filter> {
                 throw new ScriptException("No \"only on\" layer specified for \"or higher\"");
             } else if (onlyOn instanceof Layer) {
                 throw new ScriptException("No \"only on\" layer value specified for \"or higher\"");
-            } else if (((LayerValue) onlyOn).condition != null) {
+            } else if (((LayerValue) onlyOn).condition != null && ((LayerValue) onlyOn).condition != EQUAL) {
                 throw new ScriptException("Only one of \"or lower\" and \"or higher\" may be specified for \"only on\" value");
             }
             onlyOn = new LayerValue(((LayerValue) onlyOn).layer, ((LayerValue) onlyOn).value, HIGHER_THAN_OR_EQUAL);
@@ -121,7 +120,7 @@ public class CreateFilterOp extends AbstractOperation<Filter> {
         if (exceptOnLastSet) {
             if (exceptOn instanceof Layer) {
                 throw new ScriptException("No \"except on\" layer value specified for \"or lower\"");
-            } else if (((LayerValue) exceptOn).condition != null) {
+            } else if (((LayerValue) exceptOn).condition != null && ((LayerValue) exceptOn).condition != EQUAL) {
                 throw new ScriptException("Only one of \"or lower\" and \"or higher\" may be specified for \"except on\" value");
             }
             exceptOn = new LayerValue(((LayerValue) exceptOn).layer, ((LayerValue) exceptOn).value, LOWER_THAN_OR_EQUAL);
@@ -130,7 +129,7 @@ public class CreateFilterOp extends AbstractOperation<Filter> {
                 throw new ScriptException("No \"only on\" layer specified for \"or lower\"");
             } else if (onlyOn instanceof Layer) {
                 throw new ScriptException("No \"only on\" layer value specified for \"or lower\"");
-            } else if (((LayerValue) onlyOn).condition != null) {
+            } else if (((LayerValue) onlyOn).condition != null && ((LayerValue) onlyOn).condition != EQUAL) {
                 throw new ScriptException("Only one of \"or lower\" and \"or higher\" may be specified for \"only on\" value");
             }
             onlyOn = new LayerValue(((LayerValue) onlyOn).layer, ((LayerValue) onlyOn).value, LOWER_THAN_OR_EQUAL);
@@ -151,7 +150,7 @@ public class CreateFilterOp extends AbstractOperation<Filter> {
         if (onlyOn != null) {
             throw new ScriptException("Only one \"only on\" or condition may be specified");
         }
-        onlyOn = new LayerValue(Biome.INSTANCE, -biomeIndex);;
+        onlyOn = new LayerValue(Biome.INSTANCE, -biomeIndex);
         exceptOnLastSet = false;
         return this;
     }
@@ -214,7 +213,7 @@ public class CreateFilterOp extends AbstractOperation<Filter> {
         if (exceptOn != null) {
             throw new ScriptException("Only one or \"except on\" condition may be specified");
         }
-        exceptOn = new LayerValue(Biome.INSTANCE, -biomeIndex);;
+        exceptOn = new LayerValue(Biome.INSTANCE, -biomeIndex);
         exceptOnLastSet = true;
         return this;
     }


### PR DESCRIPTION
## Issue

The issue was triggered by my intention to reorganize and write the WPScript API documentation. While reviewing the code, I noticed that some interfaces were not documented in the existing API documentation. Upon attempting to use them, I discovered the following bugs.

This pull request addresses two bugs in the WorldPainter script:

1. The Filter objects returned when running `CreateFilterOp.onlyOnLayer(layer).withValue(value)` and `CreateFilterOp.exceptOnLayer(layer).withValue(value)` are opposite to the expected behavior:
```js
var layer = wp.getLayer()
    .withName('Swamp') // The name of the standard layer
    .go();

var filter = wp.createFilter() 
    .onlyOnLayer(layer).withValue(8)
    .go();
//this filter is expected to only affect areas where the layer intensity is 8, but instead, the terrain was painted everywhere except where the layer intensity is 8.
//  Similarly, the result obtained from `exceptOnLayer(layer)` is also opposite to the expected behavior.

print(filter.toString())

wp.applyTerrain(3)
    .toWorld(world)
    .withFilter(filter)
    .applyToSurface()
    .go();

```

2. The `orHigher()` / `orLower()` methods of `CreateFilterOp` are always unusable:

The JavaScript code that caused the error is as follows:
```js
var layer = wp.getLayer()
    .withName('Swamp') // The name of the standard layer
    .go();

var filter = wp.createFilter() 
    .onlyOnLayer(layer).withValue(8).toHigher()
    .go();

print(filter.toString())

wp.applyTerrain(3)
    .toWorld(world)
    .withFilter(filter)
    .applyToSurface()
    .go();
```

In the original source code, to ensure that `orHigher()` and `orLower()` are not set simultaneously, the following condition was made: 
```java
//org.pepsoft.worldpainter.tools.scripts.CreateFilterOp

public CreateFilterOp orHigher() throws ScriptException {  
    if (exceptOnLastSet) {  
        if (exceptOn instanceof Layer) 
        {  
            throw new ScriptException("No \"except on\" layer value specified for \"or higher\"");  
        } else if (((LayerValue) exceptOn).condition != null) 
        {  
            throw new ScriptException("Only one of \"or lower\" and \"or higher\" may be specified for \"except on\" value");  
        }  
        exceptOn = new LayerValue(((LayerValue) exceptOn).layer, ((LayerValue) exceptOn).value, HIGHER_THAN_OR_EQUAL);  
    } else {  
        if (onlyOn == null) 
        {  
            throw new ScriptException("No \"only on\" layer specified for \"or higher\"");  
        } else if (onlyOn instanceof Layer) 
        {  
            throw new ScriptException("No \"only on\" layer value specified for \"or higher\"");  
        } else if (((LayerValue) onlyOn).condition != null) 
        {  
            throw new ScriptException("Only one of \"or lower\" and \"or higher\" may be specified for \"only on\" value");  
        }  
        onlyOn = new LayerValue(((LayerValue) onlyOn).layer, ((LayerValue) onlyOn).value, HIGHER_THAN_OR_EQUAL);  
    }  
    return this;  
}
```

However, in practice, the constructor of `LayerValue` always initializes `onlyOn.condition` and `exceptOn.condition` to `DefaultFilter.Condition.EQUAL`. Therefore, the truth value of the condition `(LayerValue) onlyOn).condition != null` is always true.
```java
((LayerValue) exceptOn).condition != null //will be true forever
((LayerValue) onlyOn).condition != null //will be true forever
```

## Fix

1. Modified the modifyStrength() method of ExceptOnTerrainOrLayerFilter and OnlyOnTerrainOrLayerFilter to address the issue of filter operation return values.

2. Modify the judgment criteria of the orHigher() and orLower() methods to check whether they are set simultaneously based on whether the original value is QUAL or null.

## Testing

The JavaScript script for testing is as follows( Assuming the existence of `TestLayer'):
```js
var layer = wp.getLayer()
    .withName('Swamp')
    .go();

var layer0 = wp.getLayer()
    .fromWorld(world)
    .withName('TestLayer')
    .go();

var filter = wp.createFilter()
    .onlyOnLayer(layer).withValue(8).orLower()
    .exceptOnLayer(layer0).withValue(7).orHigher()
    .go();

print(filter.toString())

wp.applyTerrain(3)
    .toWorld(world)
    .withFilter(filter)
    .applyToSurface()
    .go();
```

## by the way

I am currently attempting to rewrite the WPScriptAPI documentation, filling in the gaps left by the old documentation, including sections on how to initialize UI parameters in scripts. Since English is not my first language, this might take some time, but once I'm finished, I'll promptly submit this documentation to the repository. I would greatly appreciate it if you could help review the content.

Additionally, I'm also trying to add some interesting controls to the UI parameters feature of WPScript, including combox and sliders, among others. However, these are still a work in progress. If I complete them, would you be open to incorporating these changes?
![Cache_7e81a196aed9d17b](https://github.com/Captain-Chaos/WorldPainter/assets/123755160/7c5e8cdc-a845-4a5d-a01f-35c488ff4fb5)
