### PR TITLE
Reduced number of exported chunks per region when no ceiling dimension is present.

### DIFF
--- a/WorldPainter/WPCore/src/main/java/org/pepsoft/worldpainter/exporting/AbstractWorldExporter.java
+++ b/WorldPainter/WPCore/src/main/java/org/pepsoft/worldpainter/exporting/AbstractWorldExporter.java
@@ -529,11 +529,31 @@ public abstract class AbstractWorldExporter implements WorldExporter {
         final ExportResults exportResults = new ExportResults();
         int chunkNo = 0;
         final int ceilingDelta = dimension.getMaxHeight() - dimension.getCeilingHeight();
-        for (int chunkX = lowestChunkX; chunkX <= highestChunkX; chunkX++) {
-            for (int chunkY = lowestChunkY; chunkY <= highestChunkY; chunkY++) {
+
+        final int startingChunkX;
+        final int endingChunkX;
+        final int startingChunkY;
+        final int endingChunkY;
+
+        if (ceiling){ //we must generate a chunk on both sides if using a ceiling
+            startingChunkX=lowestChunkX;
+            endingChunkX=highestChunkX;
+            startingChunkY=lowestChunkY;
+            endingChunkY=highestChunkY;
+        }else{
+            startingChunkX=lowestRegionChunkX;
+            endingChunkX=highestRegionChunkX;
+            startingChunkY=lowestRegionChunkY;
+            endingChunkY=highestRegionChunkY;
+        }
+
+        int numberOfChunksToGenerate =(endingChunkX-startingChunkX)*(endingChunkY-startingChunkY);
+
+        for (int chunkX = startingChunkX; chunkX <= endingChunkX; chunkX++) {
+            for (int chunkY = startingChunkY; chunkY <= endingChunkY; chunkY++) {
                 final ChunkFactory.ChunkCreationResult chunkCreationResult = createChunk(dimension, chunkFactory, tiles, chunkX, chunkY, tileSelection, exporters, ceiling);
                 if (chunkCreationResult != null) {
-                    if ((chunkX >= lowestRegionChunkX) && (chunkX <= highestRegionChunkX) && (chunkY >= lowestRegionChunkY) && (chunkY <= highestRegionChunkY)) {
+                    if ((!ceiling)||((chunkX >= lowestRegionChunkX) && (chunkX <= highestRegionChunkX) && (chunkY >= lowestRegionChunkY) && (chunkY <= highestRegionChunkY))) {
                         exportResults.chunksGenerated = true;
                         exportResults.stats.landArea += chunkCreationResult.stats.landArea;
                         exportResults.stats.surfaceArea += chunkCreationResult.stats.surfaceArea;
@@ -555,7 +575,7 @@ public abstract class AbstractWorldExporter implements WorldExporter {
                 }
                 chunkNo++;
                 if (progressReceiver != null) {
-                    progressReceiver.setProgress((float) chunkNo / 1156);
+                    progressReceiver.setProgress((float) chunkNo / numberOfChunksToGenerate);
                 }
             }
         }


### PR DESCRIPTION
Currently when going through firstPass, we always run through a 34 by 34 chunk area to export a region. The reason there are 2 extra per axis is because padding was being used for the ceiling dimension since chunks rely on adjacent chunks. When not using the ceiling dimension, this adds some extra overhead to exports and this can theoretically be reduced by ~11.4%.

This change will only use a 34 by 34 area when a ceiling dimension is used. Otherwise, a 32 by 32 area will be used. This is particularly useful for larger exports where we don't cut off the edges of regions because of the map size.