### PR TITLE
Don't grab random number when excessive in subsurface

### DIFF
--- a/WorldPainter/WPCore/src/main/java/org/pepsoft/worldpainter/Terrain.java
+++ b/WorldPainter/WPCore/src/main/java/org/pepsoft/worldpainter/Terrain.java
@@ -1097,7 +1097,7 @@ public enum Terrain {
                 andesiteNoise.setSeed(seed + ANDESITE_SEED_OFFSET);
                 RANDOM.setSeed(seed);
             }
-            if (z >= -RANDOM.nextInt(5)) { // TODO this is not stable
+            if (z>0 || ( z>-5 && z >= -RANDOM.nextInt(5))) { // TODO this is not stable
                 if (graniteNoise.getPerlinNoise(x / SMALL_BLOBS, y / SMALL_BLOBS, z / SMALL_BLOBS) > GRANITE_CHANCE) {
                     return Material.GRANITE;
                 } else if(dioriteNoise.getPerlinNoise(x / SMALL_BLOBS, y / SMALL_BLOBS, z / SMALL_BLOBS) > DIORITE_CHANCE) {


### PR DESCRIPTION
When using stone mix, a random number is generated for each subsurface block. Limiting it to only blocks that matter which saves a large amount of CPU on the generating step of the export. Didn't do the exact performance impact but proabably >30% reduction to the subsurface computation when using stone-mix.

The change makes sure we only generate a random number when it is within the mix range.